### PR TITLE
Add internal master clock module for independent timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,10 +66,27 @@
         </div>
 
         <div class="control-group">
+            <label for="clock-source">Clock Source</label>
+            <select id="clock-source" tabindex="-1">
+                <option value="external">External MIDI</option>
+                <option value="internal">Internal Master</option>
+                <option value="off">Off</option>
+            </select>
+        </div>
+
+        <div class="control-group" id="external-clock-controls">
             <label for="midi-clock-input">Clock Input</label>
             <select id="midi-clock-input" tabindex="-1">
                 <option value="auto">Auto (Best)</option>
             </select>
+        </div>
+
+        <div class="control-group" id="internal-clock-controls" style="display: none;">
+            <label for="internal-bpm">Internal BPM</label>
+            <div style="display:flex; gap:8px; align-items:center;">
+                <input type="number" id="internal-bpm" min="20" max="300" value="120" tabindex="-1" style="width: 70px;">
+                <button id="internal-clock-toggle" tabindex="-1">Start</button>
+            </div>
         </div>
 
         <div class="control-group">

--- a/src/clock-sync.ts
+++ b/src/clock-sync.ts
@@ -249,7 +249,15 @@ export class ClockSync {
     }
 
     this.state.source = source;
-    this.state.status = source === 'off' ? 'stopped' : this.state.status;
+
+    // Reset running state when switching to a source with no active clock
+    if (source === 'internal' || source === 'off') {
+      this.state.isRunning = false;
+      this.state.status = 'stopped';
+    } else {
+      // For external, keep current status (might reconnect to running external clock)
+      this.state.status = this.state.isRunning ? 'synced' : 'stopped';
+    }
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -1357,6 +1357,14 @@ class MIDIController {
       internalControls.style.display = source === 'internal' ? 'block' : 'none';
     }
 
+    // Update button text when switching to internal mode
+    if (source === 'internal') {
+      const button = document.getElementById('internal-clock-toggle');
+      if (button) {
+        button.textContent = this.clockSync.isInternalClockRunning() ? 'Stop' : 'Start';
+      }
+    }
+
     // Update status message
     if (source === 'internal') {
       this.uiController.updateStatus('Internal Master Clock Selected', 'info');
@@ -1381,7 +1389,9 @@ class MIDIController {
     const button = document.getElementById('internal-clock-toggle');
     if (!button) return;
 
-    if (this.clockSync.isRunning()) {
+    // Use isInternalClockRunning() to check specifically if internal clock is active
+    // (not isRunning() which could be true from external MIDI clock)
+    if (this.clockSync.isInternalClockRunning()) {
       this.clockSync.stopInternalClock();
       button.textContent = 'Start';
       this.uiController.updateStatus('Internal Clock Stopped', 'info');

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,10 +160,13 @@ export interface IMidiEngine {
   stopNote(note: number, velocity: number, channel: number): void;
 }
 
+export type ClockSource = 'external' | 'internal' | 'off';
+
 export interface ClockSyncState {
   isRunning: boolean;
   ticks: number;
   bpm: number;
   status: 'synced' | 'free' | 'stopped';
   lastTickTime: number;
+  source: ClockSource;
 }

--- a/src/ui-controller.ts
+++ b/src/ui-controller.ts
@@ -26,6 +26,9 @@ export class UIController {
   private clockStatusElement: HTMLElement;
   private midiClockInputSelect: HTMLSelectElement | null = null;
   private midiNoteInputSelect: HTMLSelectElement | null = null;
+  private clockSourceSelect: HTMLSelectElement | null = null;
+  private internalBPMInput: HTMLInputElement | null = null;
+  private internalClockToggle: HTMLButtonElement | null = null;
   private beatIndicatorTimeout?: ReturnType<typeof setTimeout>; // Store timeout to prevent overlapping pulses
   private modIndicator: HTMLElement | null = null;
   private pitchIndicator: HTMLElement | null = null;
@@ -61,6 +64,9 @@ export class UIController {
     this.clockStatusElement = document.getElementById('clock-status')!;
     this.midiClockInputSelect = document.getElementById('midi-clock-input') as HTMLSelectElement | null;
     this.midiNoteInputSelect = document.getElementById('midi-note-input') as HTMLSelectElement | null;
+    this.clockSourceSelect = document.getElementById('clock-source') as HTMLSelectElement | null;
+    this.internalBPMInput = document.getElementById('internal-bpm') as HTMLInputElement | null;
+    this.internalClockToggle = document.getElementById('internal-clock-toggle') as HTMLButtonElement | null;
     this.modIndicator = document.getElementById('mod-indicator');
     this.pitchIndicator = document.getElementById('pitch-indicator');
     this.octaveDownIndicator = document.getElementById('octave-down-indicator');
@@ -928,6 +934,39 @@ export class UIController {
     if (!this.midiNoteInputSelect) return;
     this.midiNoteInputSelect.addEventListener('change', () => {
       handler(this.midiNoteInputSelect!.value);
+    });
+  }
+
+  /**
+   * Register handler for clock source changes
+   */
+  onClockSourceChange(handler: (source: string) => void): void {
+    if (!this.clockSourceSelect) return;
+    this.clockSourceSelect.addEventListener('change', () => {
+      handler(this.clockSourceSelect!.value);
+    });
+  }
+
+  /**
+   * Register handler for internal BPM changes
+   */
+  onInternalBPMChange(handler: (bpm: number) => void): void {
+    if (!this.internalBPMInput) return;
+    this.internalBPMInput.addEventListener('change', () => {
+      const bpm = parseInt(this.internalBPMInput!.value);
+      if (!isNaN(bpm)) {
+        handler(bpm);
+      }
+    });
+  }
+
+  /**
+   * Register handler for internal clock toggle
+   */
+  onInternalClockToggle(handler: () => void): void {
+    if (!this.internalClockToggle) return;
+    this.internalClockToggle.addEventListener('click', () => {
+      handler();
     });
   }
 

--- a/tests/unit/clock-sync.test.ts
+++ b/tests/unit/clock-sync.test.ts
@@ -293,5 +293,36 @@ describe('ClockSync', () => {
       // Should have roughly double the ticks
       expect(ticks240).toBeGreaterThan(ticks120 * 1.8); // Allow some tolerance
     });
+
+    it('should reset isRunning when switching from external to internal source', () => {
+      // Simulate external clock running
+      clockSync.onMIDIStart();
+      expect(clockSync.isRunning()).toBe(true);
+
+      // Switch to internal source
+      clockSync.setClockSource('internal');
+
+      // isRunning should be reset because internal clock hasn't started yet
+      expect(clockSync.isRunning()).toBe(false);
+      expect(clockSync.isInternalClockRunning()).toBe(false);
+
+      // Now start internal clock
+      clockSync.startInternalClock();
+      expect(clockSync.isRunning()).toBe(true);
+      expect(clockSync.isInternalClockRunning()).toBe(true);
+    });
+
+    it('should reset isRunning when switching to off source', () => {
+      // Simulate external clock running
+      clockSync.onMIDIStart();
+      expect(clockSync.isRunning()).toBe(true);
+
+      // Switch to off
+      clockSync.setClockSource('off');
+
+      // isRunning should be reset
+      expect(clockSync.isRunning()).toBe(false);
+      expect(clockSync.getStatus()).toBe('stopped');
+    });
   });
 });


### PR DESCRIPTION
Implemented a master clock module that generates its own MIDI clock ticks
internally, allowing the application to function as a timing source instead
of only listening to external DAW clock signals.

Key changes:
- Created MasterClock class that generates clock ticks at configurable BPM
- Integrated MasterClock with existing ClockSync architecture
- Added UI controls for clock source selection (External/Internal/Off)
- Added BPM control and Start/Stop button for internal clock
- Updated ClockSync to route events from external or internal clock based on source
- Added ClockSource type to support multiple timing modes
- UI dynamically shows/hides controls based on selected clock source

The arpeggiator and other clock-dependent features now work with both
external MIDI clock and the new internal master clock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an internal timing source and unified clock management across the app.
> 
> - **Clocking:** `ClockSync` now supports `external`/`internal`/`off` sources, generates internal 24 PPQN ticks at set `bpm`, exposes `setClockSource`, `getClockSource`, `setInternalBPM`, `startInternalClock`, `stopInternalClock`, `isInternalClockRunning`, and ensures external MIDI is ignored when internal/off; `clearCallbacks` also stops the internal interval
> - **UI:** Adds `clock-source` selector and internal controls (`internal-bpm`, `internal-clock-toggle`) in `index.html`; `UIController` exposes handlers for clock source/BPM/toggle
> - **App wiring:** `main.ts` wires new UI handlers, updates status/visibility, and persists/restores clock source, running state, and BPM across cleanup/resume
> - **Types:** Adds `ClockSource` and includes `source` in `ClockSyncState`
> - **Tests:** Expands `clock-sync` unit tests to cover internal clock operation, BPM changes, source switching, and edge cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 315b3a04e9bfe7416aa082fe0d563e4e391ba501. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->