### PR TITLE
Fix keyboard controls after UI interaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,13 @@ npm run electron-serve         # Launch Electron app
 
 ### Day-1 Checklist
 
-1. `npm run setup` — lightweight install
+1. `npm run setup` — lightweight install **(MUST run before type-check)**
 2. `git fetch origin && git merge origin/main` — sync before edits
 3. `npm run type-check` — verify compilation
 4. `npm run test` — run unit tests
 5. `npm run dev` — start dev server on :8080 (if needed)
+
+> **⚠️ IMPORTANT**: Always run `npm run setup` before `npm run type-check`. The type-check will fail with `Cannot find namespace 'WebMidi'` errors if `@types/webmidi` is not installed. This is a dependency issue, not a code issue—do not attempt to fix these errors by modifying source files.
 
 ### Quick File Reference
 
@@ -58,6 +60,7 @@ npm run electron-serve         # Launch Electron app
 
 | Symptom | Check |
 |---------|-------|
+| `Cannot find namespace 'WebMidi'` type errors | Run `npm run setup` first—this installs `@types/webmidi` |
 | No MIDI ports | Create virtual MIDI port (IAC/loopMIDI), grant browser permissions |
 | Clock not syncing | Route DAW clock to selected clock port, verify in-app selector |
 | Arpeggiator silent | Enable toggle, hold notes, confirm clock running + beat indicator |

--- a/index.html
+++ b/index.html
@@ -32,13 +32,13 @@
     <div class="controls">
         <div class="control-group">
             <label for="velocity">Velocity</label>
-            <input type="range" id="velocity" min="1" max="127" value="80">
+            <input type="range" id="velocity" min="1" max="127" value="80" tabindex="-1">
             <span id="velocity-value">80</span>
         </div>
         
         <div class="control-group">
             <label for="midi-channel">MIDI Channel</label>
-            <select id="midi-channel">
+            <select id="midi-channel" tabindex="-1">
                 <option value="1">1</option>
                 <option value="2">2</option>
                 <option value="3">3</option>
@@ -60,14 +60,14 @@
         
         <div class="control-group">
             <label for="midi-note-input">Note Input</label>
-            <select id="midi-note-input">
+            <select id="midi-note-input" tabindex="-1">
                 <option value="keyboard">QWERTY Keyboard</option>
             </select>
         </div>
 
         <div class="control-group">
             <label for="midi-clock-input">Clock Input</label>
-            <select id="midi-clock-input">
+            <select id="midi-clock-input" tabindex="-1">
                 <option value="auto">Auto (Best)</option>
             </select>
         </div>
@@ -90,7 +90,7 @@
         
         <div class="control-group">
             <label>Keyboard Layout</label>
-            <select id="layout-select">
+            <select id="layout-select" tabindex="-1">
                 <option value="expanded">Expanded</option>
                 <option value="simple">Simple</option>
             </select>
@@ -98,13 +98,13 @@
 
         <div class="control-group">
             <label>Scale Filter</label>
-            <button id="scale-filter-toggle">Enable Scale Filter</button>
+            <button id="scale-filter-toggle" tabindex="-1">Enable Scale Filter</button>
         </div>
 
         <div class="scale-filter-controls" id="scale-filter-controls" style="display: none;">
             <div class="control-group">
                 <label for="scale-root">Root Note</label>
-                <select id="scale-root">
+                <select id="scale-root" tabindex="-1">
                     <option value="0">C</option>
                     <option value="1">C#</option>
                     <option value="2">D</option>
@@ -121,7 +121,7 @@
             </div>
             <div class="control-group">
                 <label for="scale-type">Scale Type</label>
-                <select id="scale-type">
+                <select id="scale-type" tabindex="-1">
                     <option value="chromatic" selected>Chromatic (All Notes)</option>
                     <option value="major">Major (Ionian)</option>
                     <option value="minor">Natural Minor (Aeolian)</option>
@@ -144,14 +144,14 @@
 
         <div class="control-group">
             <label>Actions</label>
-            <button id="panic-button">Stop All Notes</button>
-            <button id="arpeggiator-toggle">Enable Arpeggiator</button>
+            <button id="panic-button" tabindex="-1">Stop All Notes</button>
+            <button id="arpeggiator-toggle" tabindex="-1">Enable Arpeggiator</button>
         </div>
         
         <div class="arpeggiator-controls" id="arpeggiator-controls" style="display: none;">
             <div class="control-group">
                 <label>Pattern</label>
-                <select id="arp-pattern">
+                <select id="arp-pattern" tabindex="-1">
                     <option value="up">Up</option>
                     <option value="down">Down</option>
                     <option value="up-down">Up-Down</option>
@@ -164,7 +164,7 @@
             </div>
             <div class="control-group">
                 <label>Division</label>
-                <select id="arp-division">
+                <select id="arp-division" tabindex="-1">
                     <option value="1">1</option>
                     <option value="2">1/2</option>
                     <option value="4" selected>1/4</option>
@@ -173,12 +173,12 @@
             </div>
             <div class="control-group">
                 <label id="arp-gate-label" for="arp-gate">Gate</label>
-                <input type="range" id="arp-gate" min="0" max="100" value="50">
+                <input type="range" id="arp-gate" min="0" max="100" value="50" tabindex="-1">
                 <span id="arp-gate-value">50%</span>
             </div>
             <div class="control-group">
                 <label for="arp-timing-type">Timing Feel</label>
-                <select id="arp-timing-type">
+                <select id="arp-timing-type" tabindex="-1">
                     <option value="straight">Straight</option>
                     <option value="swing">Swing</option>
                     <option value="shuffle">Shuffle (Triplet)</option>
@@ -187,19 +187,19 @@
             </div>
             <div class="control-group">
                 <label>
-                    <input type="checkbox" id="arp-humanize">
+                    <input type="checkbox" id="arp-humanize" tabindex="-1">
                     Humanize
                 </label>
             </div>
             <div class="control-group">
                 <label>
-                    <input type="checkbox" id="arp-humanize-velocity">
+                    <input type="checkbox" id="arp-humanize-velocity" tabindex="-1">
                     Humanize Velocity
                 </label>
             </div>
             <div class="control-group">
                 <label for="arp-accent">Accent</label>
-                <select id="arp-accent">
+                <select id="arp-accent" tabindex="-1">
                     <option value="none">None</option>
                     <option value="downbeats">Downbeats</option>
                     <option value="offbeats">Offbeats</option>
@@ -208,12 +208,12 @@
             </div>
             <div class="control-group">
                 <label>Probability</label>
-                <input type="range" id="arp-probability" min="0" max="100" value="100">
+                <input type="range" id="arp-probability" min="0" max="100" value="100" tabindex="-1">
                 <span id="arp-probability-value">100%</span>
             </div>
             <div class="control-group">
                 <label for="arp-ratchet">Ratchet</label>
-                <select id="arp-ratchet">
+                <select id="arp-ratchet" tabindex="-1">
                     <option value="1">Off</option>
                     <option value="2">2x</option>
                     <option value="3">3x</option>
@@ -222,7 +222,7 @@
             </div>
             <div class="control-group">
                 <label>
-                    <input type="checkbox" id="latch-mode">
+                    <input type="checkbox" id="latch-mode" tabindex="-1">
                     Latch Mode
                 </label>
             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -265,7 +265,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -309,7 +308,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -818,6 +816,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -839,6 +838,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -855,6 +855,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -869,6 +870,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2030,7 +2032,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2358,7 +2359,6 @@
       "integrity": "sha512-rkoPH+RqWopVxDnCBE/ysIdfQ2A7j1eDmW8tCxxrR9nnFBa9jKf86VgsSAzxBd1x+ny0GC4JgiD3SNfRHv3pOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.16",
         "fflate": "^0.8.2",
@@ -2456,7 +2456,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3387,7 +3386,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3640,7 +3640,6 @@
       "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.0.12",
         "builder-util": "26.0.11",
@@ -3950,6 +3949,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -3970,6 +3970,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6145,7 +6146,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6265,6 +6265,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -6282,6 +6283,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -7166,6 +7168,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -7229,6 +7232,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -7243,6 +7247,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7543,7 +7548,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7619,7 +7623,6 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",

--- a/src/keyboard-input.ts
+++ b/src/keyboard-input.ts
@@ -160,6 +160,7 @@ export class KeyboardInput {
     // Check for special keys first
     if (this.specialKeyHandlers.has(event.code)) {
       event.preventDefault();
+      event.stopPropagation(); // Prevent reaching focused UI elements
       this.specialKeyHandlers.get(event.code)!();
       return;
     }
@@ -168,6 +169,7 @@ export class KeyboardInput {
     const noteOffset = this.currentLayout.keys[event.code];
     if (noteOffset !== undefined) {
       event.preventDefault();
+      event.stopPropagation(); // Prevent reaching focused UI elements
 
       // Latch mode: toggle behavior
       if (this.latchMode) {
@@ -191,21 +193,26 @@ export class KeyboardInput {
     // Check for octave control keys
     if (event.code === this.currentLayout.octaveDownKey) {
       event.preventDefault();
+      event.stopPropagation();
       this.specialKeyHandlers.get('octaveDown')?.();
     } else if (event.code === this.currentLayout.octaveUpKey) {
       event.preventDefault();
+      event.stopPropagation();
       this.specialKeyHandlers.get('octaveUp')?.();
     } else if (event.code === 'ArrowUp') {
       // Mod wheel full on while held
       event.preventDefault();
+      event.stopPropagation();
       this.specialKeyHandlers.get('modOn')?.();
     } else if (event.code === 'ArrowDown') {
       // Pitch bend full down while held
       event.preventDefault();
+      event.stopPropagation();
       this.specialKeyHandlers.get('pitchDownOn')?.();
     } else if (event.code === 'Tab') {
       // Arp division/rate boost while held
       event.preventDefault();
+      event.stopPropagation();
       this.specialKeyHandlers.get('arpBoostOn')?.();
     }
   }

--- a/src/keyboard-input.ts
+++ b/src/keyboard-input.ts
@@ -155,6 +155,11 @@ export class KeyboardInput {
          ['text', 'search', 'email', 'password', 'url', 'tel', 'number'].includes(target.type)) ||
         target.isContentEditable) return;
 
+    // Prevent all keyboard behavior on selects (type-to-search, arrow navigation)
+    if (target instanceof HTMLSelectElement) {
+      event.preventDefault();
+    }
+
     this.pressedKeys.add(event.code);
 
     // Check for special keys first

--- a/src/keyboard-input.ts
+++ b/src/keyboard-input.ts
@@ -148,9 +148,12 @@ export class KeyboardInput {
     // Ignore repeated events for our app logic (but still prevent default above)
     if (this.pressedKeys.has(event.code)) return;
     
-    // Ignore if typing in input field
-    if (event.target instanceof HTMLInputElement || 
-        event.target instanceof HTMLTextAreaElement) return;
+    // Ignore if typing in a text-entry field (but allow non-text inputs like sliders/selects)
+    const target = event.target as HTMLElement;
+    if (target instanceof HTMLTextAreaElement ||
+        (target instanceof HTMLInputElement &&
+         ['text', 'search', 'email', 'password', 'url', 'tel', 'number'].includes(target.type)) ||
+        target.isContentEditable) return;
 
     this.pressedKeys.add(event.code);
 

--- a/src/keyboard-input.ts
+++ b/src/keyboard-input.ts
@@ -155,11 +155,6 @@ export class KeyboardInput {
          ['text', 'search', 'email', 'password', 'url', 'tel', 'number'].includes(target.type)) ||
         target.isContentEditable) return;
 
-    // Prevent all keyboard behavior on selects (type-to-search, arrow navigation)
-    if (target instanceof HTMLSelectElement) {
-      event.preventDefault();
-    }
-
     this.pressedKeys.add(event.code);
 
     // Check for special keys first

--- a/src/ui-controller.ts
+++ b/src/ui-controller.ts
@@ -122,13 +122,7 @@ export class UIController {
         }
       });
     });
-
-    // Disable keyboard navigation on dropdowns - mouse clicks only
-    document.querySelectorAll('select').forEach(element => {
-      element.addEventListener('keydown', (e) => {
-        e.preventDefault();
-      });
-    });
+    // Note: Dropdown keyboard behavior is disabled in keyboard-input.ts (capture phase)
   }
 
   /**

--- a/src/ui-controller.ts
+++ b/src/ui-controller.ts
@@ -122,6 +122,15 @@ export class UIController {
         }
       });
     });
+
+    // Auto-blur non-text controls after interaction to return keyboard focus to instrument
+    document.querySelectorAll('select, input[type="range"], input[type="checkbox"]').forEach(element => {
+      const htmlElement = element as HTMLElement;
+      // Use 'change' for selects/checkboxes, 'input' would fire too often for range
+      element.addEventListener('change', () => {
+        htmlElement.blur();
+      });
+    });
   }
 
   /**

--- a/src/ui-controller.ts
+++ b/src/ui-controller.ts
@@ -124,10 +124,11 @@ export class UIController {
     });
 
     // Auto-blur non-text controls after interaction to return keyboard focus to instrument
-    document.querySelectorAll('select, input[type="range"], input[type="checkbox"]').forEach(element => {
+    document.querySelectorAll('select, input[type="range"], input[type="checkbox"], button').forEach(element => {
       const htmlElement = element as HTMLElement;
-      // Use 'change' for selects/checkboxes, 'input' would fire too often for range
-      element.addEventListener('change', () => {
+      // Use 'change' for selects/checkboxes/ranges, 'click' for buttons
+      const eventType = element.tagName === 'BUTTON' ? 'click' : 'change';
+      element.addEventListener(eventType, () => {
         htmlElement.blur();
       });
     });

--- a/src/ui-controller.ts
+++ b/src/ui-controller.ts
@@ -123,13 +123,10 @@ export class UIController {
       });
     });
 
-    // Auto-blur non-text controls after interaction to return keyboard focus to instrument
-    document.querySelectorAll('select, input[type="range"], input[type="checkbox"], button').forEach(element => {
-      const htmlElement = element as HTMLElement;
-      // Use 'change' for selects/checkboxes/ranges, 'click' for buttons
-      const eventType = element.tagName === 'BUTTON' ? 'click' : 'change';
-      element.addEventListener(eventType, () => {
-        htmlElement.blur();
+    // Disable keyboard navigation on dropdowns - mouse clicks only
+    document.querySelectorAll('select').forEach(element => {
+      element.addEventListener('keydown', (e) => {
+        e.preventDefault();
       });
     });
   }

--- a/tests/unit/keyboard-input.test.ts
+++ b/tests/unit/keyboard-input.test.ts
@@ -534,6 +534,34 @@ describe('KeyboardInput', () => {
       document.body.removeChild(select);
     });
 
+    it('should block native keyboard behavior on select elements (expanded dropdown support)', () => {
+      // This ensures notes can play while a dropdown is open/expanded
+      const select = document.createElement('select');
+      const option1 = document.createElement('option');
+      option1.value = 'a';
+      option1.textContent = 'Option A';
+      const option2 = document.createElement('option');
+      option2.value = 'b';
+      option2.textContent = 'Option B';
+      select.appendChild(option1);
+      select.appendChild(option2);
+      document.body.appendChild(select);
+
+      const event = new KeyboardEvent('keydown', {
+        code: 'KeyA', // 'A' would normally trigger type-to-search in a select
+        bubbles: true,
+        cancelable: true
+      });
+
+      Object.defineProperty(event, 'target', { value: select, enumerable: true });
+      document.dispatchEvent(event);
+
+      // preventDefault should have been called to block native select behavior
+      expect(event.defaultPrevented).toBe(true);
+
+      document.body.removeChild(select);
+    });
+
     it('should ignore keydown events from password inputs', () => {
       keyboardInput.onNoteOn('KeyZ', noteOnHandler);
 

--- a/tests/unit/keyboard-input.test.ts
+++ b/tests/unit/keyboard-input.test.ts
@@ -414,10 +414,11 @@ describe('KeyboardInput', () => {
   });
 
   describe('Input Field Filtering', () => {
-    it('should ignore keydown events from input fields', () => {
+    it('should ignore keydown events from text input fields', () => {
       keyboardInput.onNoteOn('KeyZ', noteOnHandler);
 
       const input = document.createElement('input');
+      input.type = 'text';
       document.body.appendChild(input);
 
       const event = new KeyboardEvent('keydown', {
@@ -450,6 +451,127 @@ describe('KeyboardInput', () => {
       expect(noteOnHandler).not.toHaveBeenCalled();
 
       document.body.removeChild(textarea);
+    });
+
+    it('should ignore keydown events from contenteditable elements', () => {
+      keyboardInput.onNoteOn('KeyZ', noteOnHandler);
+
+      const div = document.createElement('div');
+      div.contentEditable = 'true';
+      // jsdom may not set isContentEditable correctly, so mock it
+      Object.defineProperty(div, 'isContentEditable', { value: true, configurable: true });
+      document.body.appendChild(div);
+
+      const event = new KeyboardEvent('keydown', {
+        code: 'KeyZ',
+        bubbles: true
+      });
+
+      Object.defineProperty(event, 'target', { value: div, enumerable: true });
+      document.dispatchEvent(event);
+
+      expect(noteOnHandler).not.toHaveBeenCalled();
+
+      document.body.removeChild(div);
+    });
+
+    it('should allow keydown events from range inputs (sliders)', () => {
+      keyboardInput.onNoteOn('KeyZ', noteOnHandler);
+
+      const input = document.createElement('input');
+      input.type = 'range';
+      document.body.appendChild(input);
+
+      const event = new KeyboardEvent('keydown', {
+        code: 'KeyZ',
+        bubbles: true
+      });
+
+      Object.defineProperty(event, 'target', { value: input, enumerable: true });
+      document.dispatchEvent(event);
+
+      expect(noteOnHandler).toHaveBeenCalled();
+
+      document.body.removeChild(input);
+    });
+
+    it('should allow keydown events from checkbox inputs', () => {
+      keyboardInput.onNoteOn('KeyZ', noteOnHandler);
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      document.body.appendChild(input);
+
+      const event = new KeyboardEvent('keydown', {
+        code: 'KeyZ',
+        bubbles: true
+      });
+
+      Object.defineProperty(event, 'target', { value: input, enumerable: true });
+      document.dispatchEvent(event);
+
+      expect(noteOnHandler).toHaveBeenCalled();
+
+      document.body.removeChild(input);
+    });
+
+    it('should allow keydown events from select elements', () => {
+      keyboardInput.onNoteOn('KeyZ', noteOnHandler);
+
+      const select = document.createElement('select');
+      document.body.appendChild(select);
+
+      const event = new KeyboardEvent('keydown', {
+        code: 'KeyZ',
+        bubbles: true
+      });
+
+      Object.defineProperty(event, 'target', { value: select, enumerable: true });
+      document.dispatchEvent(event);
+
+      expect(noteOnHandler).toHaveBeenCalled();
+
+      document.body.removeChild(select);
+    });
+
+    it('should ignore keydown events from password inputs', () => {
+      keyboardInput.onNoteOn('KeyZ', noteOnHandler);
+
+      const input = document.createElement('input');
+      input.type = 'password';
+      document.body.appendChild(input);
+
+      const event = new KeyboardEvent('keydown', {
+        code: 'KeyZ',
+        bubbles: true
+      });
+
+      Object.defineProperty(event, 'target', { value: input, enumerable: true });
+      document.dispatchEvent(event);
+
+      expect(noteOnHandler).not.toHaveBeenCalled();
+
+      document.body.removeChild(input);
+    });
+
+    it('should ignore keydown events from email inputs', () => {
+      keyboardInput.onNoteOn('KeyZ', noteOnHandler);
+
+      const input = document.createElement('input');
+      input.type = 'email';
+      document.body.appendChild(input);
+
+      const event = new KeyboardEvent('keydown', {
+        code: 'KeyZ',
+        bubbles: true
+      });
+
+      Object.defineProperty(event, 'target', { value: input, enumerable: true });
+      document.dispatchEvent(event);
+
+      expect(noteOnHandler).not.toHaveBeenCalled();
+
+      document.body.removeChild(input);
     });
   });
 

--- a/tests/unit/keyboard-input.test.ts
+++ b/tests/unit/keyboard-input.test.ts
@@ -515,7 +515,9 @@ describe('KeyboardInput', () => {
       document.body.removeChild(input);
     });
 
-    it('should allow keydown events from select elements', () => {
+    it('should allow keydown events from select elements (when not expanded)', () => {
+      // Note: When a native <select> is expanded, browser takes full keyboard control.
+      // This is a browser limitation. Notes only play when dropdown is focused but closed.
       keyboardInput.onNoteOn('KeyZ', noteOnHandler);
 
       const select = document.createElement('select');
@@ -530,34 +532,6 @@ describe('KeyboardInput', () => {
       document.dispatchEvent(event);
 
       expect(noteOnHandler).toHaveBeenCalled();
-
-      document.body.removeChild(select);
-    });
-
-    it('should block native keyboard behavior on select elements (expanded dropdown support)', () => {
-      // This ensures notes can play while a dropdown is open/expanded
-      const select = document.createElement('select');
-      const option1 = document.createElement('option');
-      option1.value = 'a';
-      option1.textContent = 'Option A';
-      const option2 = document.createElement('option');
-      option2.value = 'b';
-      option2.textContent = 'Option B';
-      select.appendChild(option1);
-      select.appendChild(option2);
-      document.body.appendChild(select);
-
-      const event = new KeyboardEvent('keydown', {
-        code: 'KeyA', // 'A' would normally trigger type-to-search in a select
-        bubbles: true,
-        cancelable: true
-      });
-
-      Object.defineProperty(event, 'target', { value: select, enumerable: true });
-      document.dispatchEvent(event);
-
-      // preventDefault should have been called to block native select behavior
-      expect(event.defaultPrevented).toBe(true);
 
       document.body.removeChild(select);
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves reliability of QWERTY note/special keys after interacting with the UI.
> 
> - Keyboard: refine input filtering to ignore only text-entry targets (`input[type=text|…]`, `textarea`, `contenteditable`) and `stopPropagation()` for note/special keys to avoid focused elements capturing them
> - HTML: add `tabindex="-1"` to sliders/selects/buttons to keep them out of the tab sequence and reduce focus interference
> - Tests: expand `keyboard-input` coverage for contenteditable, range/checkbox/select allowance, and various input types
> - Docs: update `CLAUDE.md` with a mandatory `npm run setup` before type-check note and troubleshooting tip for `WebMidi` types
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c26dc1c4365efca169698a245f6b99c519682797. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->