### PR TITLE
Refactor arp controls from dropdowns to button groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,82 +149,97 @@
         </div>
         
         <div class="arpeggiator-controls" id="arpeggiator-controls" style="display: none;">
-            <div class="control-group">
-                <label>Pattern</label>
-                <select id="arp-pattern" tabindex="-1">
-                    <option value="up">Up</option>
-                    <option value="down">Down</option>
-                    <option value="up-down">Up-Down</option>
-                    <option value="down-up">Down-Up</option>
-                    <option value="random">Random</option>
-                    <option value="chord">Chord</option>
-                    <option value="stacked-chord">Stacked Chord</option>
-                    <option value="timeline">Timeline</option>
-                </select>
+            <!-- Row 1: Pattern -->
+            <div class="arp-row">
+                <div class="control-group">
+                    <label>Pattern</label>
+                    <div class="btn-group" id="arp-pattern" data-value="up">
+                        <button type="button" class="btn-group-item active" data-value="up" tabindex="-1">Up</button>
+                        <button type="button" class="btn-group-item" data-value="down" tabindex="-1">Down</button>
+                        <button type="button" class="btn-group-item" data-value="up-down" tabindex="-1">U-D</button>
+                        <button type="button" class="btn-group-item" data-value="down-up" tabindex="-1">D-U</button>
+                        <button type="button" class="btn-group-item" data-value="random" tabindex="-1">Rnd</button>
+                        <button type="button" class="btn-group-item" data-value="chord" tabindex="-1">Chrd</button>
+                        <button type="button" class="btn-group-item" data-value="stacked-chord" tabindex="-1">Stk</button>
+                        <button type="button" class="btn-group-item" data-value="timeline" tabindex="-1">Time</button>
+                    </div>
+                </div>
             </div>
-            <div class="control-group">
-                <label>Division</label>
-                <select id="arp-division" tabindex="-1">
-                    <option value="1">1</option>
-                    <option value="2">1/2</option>
-                    <option value="4" selected>1/4</option>
-                    <option value="8">1/8</option>
-                </select>
+            <!-- Row 2: Division + Timing -->
+            <div class="arp-row">
+                <div class="control-group">
+                    <label>Division</label>
+                    <div class="btn-group" id="arp-division" data-value="4">
+                        <button type="button" class="btn-group-item" data-value="1" tabindex="-1">1</button>
+                        <button type="button" class="btn-group-item" data-value="2" tabindex="-1">1/2</button>
+                        <button type="button" class="btn-group-item active" data-value="4" tabindex="-1">1/4</button>
+                        <button type="button" class="btn-group-item" data-value="8" tabindex="-1">1/8</button>
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label>Timing</label>
+                    <div class="btn-group" id="arp-timing-type" data-value="straight">
+                        <button type="button" class="btn-group-item active" data-value="straight" tabindex="-1">Str</button>
+                        <button type="button" class="btn-group-item" data-value="swing" tabindex="-1">Swng</button>
+                        <button type="button" class="btn-group-item" data-value="shuffle" tabindex="-1">Shfl</button>
+                        <button type="button" class="btn-group-item" data-value="dotted" tabindex="-1">Dot</button>
+                    </div>
+                </div>
             </div>
-            <div class="control-group">
-                <label id="arp-gate-label" for="arp-gate">Gate</label>
-                <input type="range" id="arp-gate" min="0" max="100" value="50" tabindex="-1">
-                <span id="arp-gate-value">50%</span>
+            <!-- Row 3: Accent + Ratchet -->
+            <div class="arp-row">
+                <div class="control-group">
+                    <label>Accent</label>
+                    <div class="btn-group" id="arp-accent" data-value="none">
+                        <button type="button" class="btn-group-item active" data-value="none" tabindex="-1">Off</button>
+                        <button type="button" class="btn-group-item" data-value="downbeats" tabindex="-1">Down</button>
+                        <button type="button" class="btn-group-item" data-value="offbeats" tabindex="-1">Off</button>
+                        <button type="button" class="btn-group-item" data-value="every-3rd" tabindex="-1">3rd</button>
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label>Ratchet</label>
+                    <div class="btn-group" id="arp-ratchet" data-value="1">
+                        <button type="button" class="btn-group-item active" data-value="1" tabindex="-1">Off</button>
+                        <button type="button" class="btn-group-item" data-value="2" tabindex="-1">2x</button>
+                        <button type="button" class="btn-group-item" data-value="3" tabindex="-1">3x</button>
+                        <button type="button" class="btn-group-item" data-value="4" tabindex="-1">4x</button>
+                    </div>
+                </div>
             </div>
-            <div class="control-group">
-                <label for="arp-timing-type">Timing Feel</label>
-                <select id="arp-timing-type" tabindex="-1">
-                    <option value="straight">Straight</option>
-                    <option value="swing">Swing</option>
-                    <option value="shuffle">Shuffle (Triplet)</option>
-                    <option value="dotted">Dotted</option>
-                </select>
+            <!-- Row 4: Gate + Probability sliders -->
+            <div class="arp-row">
+                <div class="control-group">
+                    <label id="arp-gate-label" for="arp-gate">Gate</label>
+                    <input type="range" id="arp-gate" min="0" max="100" value="50" tabindex="-1">
+                    <span id="arp-gate-value">50%</span>
+                </div>
+                <div class="control-group">
+                    <label>Probability</label>
+                    <input type="range" id="arp-probability" min="0" max="100" value="100" tabindex="-1">
+                    <span id="arp-probability-value">100%</span>
+                </div>
             </div>
-            <div class="control-group">
-                <label>
-                    <input type="checkbox" id="arp-humanize" tabindex="-1">
-                    Humanize
-                </label>
-            </div>
-            <div class="control-group">
-                <label>
-                    <input type="checkbox" id="arp-humanize-velocity" tabindex="-1">
-                    Humanize Velocity
-                </label>
-            </div>
-            <div class="control-group">
-                <label for="arp-accent">Accent</label>
-                <select id="arp-accent" tabindex="-1">
-                    <option value="none">None</option>
-                    <option value="downbeats">Downbeats</option>
-                    <option value="offbeats">Offbeats</option>
-                    <option value="every-3rd">Every 3rd</option>
-                </select>
-            </div>
-            <div class="control-group">
-                <label>Probability</label>
-                <input type="range" id="arp-probability" min="0" max="100" value="100" tabindex="-1">
-                <span id="arp-probability-value">100%</span>
-            </div>
-            <div class="control-group">
-                <label for="arp-ratchet">Ratchet</label>
-                <select id="arp-ratchet" tabindex="-1">
-                    <option value="1">Off</option>
-                    <option value="2">2x</option>
-                    <option value="3">3x</option>
-                    <option value="4">4x</option>
-                </select>
-            </div>
-            <div class="control-group">
-                <label>
-                    <input type="checkbox" id="latch-mode" tabindex="-1">
-                    Latch Mode
-                </label>
+            <!-- Row 5: Checkboxes -->
+            <div class="arp-row">
+                <div class="control-group">
+                    <label>
+                        <input type="checkbox" id="arp-humanize" tabindex="-1">
+                        Humanize
+                    </label>
+                </div>
+                <div class="control-group">
+                    <label>
+                        <input type="checkbox" id="arp-humanize-velocity" tabindex="-1">
+                        Humanize Velocity
+                    </label>
+                </div>
+                <div class="control-group">
+                    <label>
+                        <input type="checkbox" id="latch-mode" tabindex="-1">
+                        Latch Mode
+                    </label>
+                </div>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -191,9 +191,9 @@
                 <div class="control-group">
                     <label>Accent</label>
                     <div class="btn-group" id="arp-accent" data-value="none">
-                        <button type="button" class="btn-group-item active" data-value="none" tabindex="-1">Off</button>
+                        <button type="button" class="btn-group-item active" data-value="none" tabindex="-1">None</button>
                         <button type="button" class="btn-group-item" data-value="downbeats" tabindex="-1">Down</button>
-                        <button type="button" class="btn-group-item" data-value="offbeats" tabindex="-1">Off</button>
+                        <button type="button" class="btn-group-item" data-value="offbeats" tabindex="-1">Up</button>
                         <button type="button" class="btn-group-item" data-value="every-3rd" tabindex="-1">3rd</button>
                     </div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -251,6 +251,59 @@ body {
     opacity: 0.8;
 }
 
+/* Button Group - horizontal toggle buttons replacing dropdowns */
+.btn-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    justify-content: center;
+}
+
+.btn-group-item {
+    background: var(--control-bg);
+    border: 1px solid var(--control-border);
+    color: var(--text-color);
+    padding: 6px 10px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    min-width: 36px;
+    text-align: center;
+    user-select: none;
+}
+
+.btn-group-item:hover {
+    background: var(--button-hover-bg);
+    border-color: var(--panel-border-strong);
+}
+
+.btn-group-item.active {
+    background: rgba(76, 175, 80, 0.4);
+    border-color: #4CAF50;
+    color: #ffffff;
+    box-shadow: 0 0 8px rgba(76, 175, 80, 0.4);
+}
+
+.btn-group-item:focus {
+    outline: none;
+}
+
+/* Arpeggiator controls row layout */
+.arp-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+    width: 100%;
+    justify-content: center;
+    align-items: flex-start;
+}
+
+.arp-row .control-group {
+    flex: 0 1 auto;
+}
+
 .controls {
     display: flex;
     gap: 20px;


### PR DESCRIPTION
Convert arpeggiator dropdown selects to horizontal button groups to
eliminate keyboard capture issues when dropdowns are expanded. Native
browser dropdowns capture all keyboard input when open, preventing
the MIDI keyboard from working during selection.

Changes:
- Replace 5 dropdown selects with button groups (Pattern, Division,
  Timing, Accent, Ratchet)
- Add btn-group CSS styles with active state highlighting
- Add btn-group type support in wireControls
- Update arp boost feature to work with button groups
- Organize arp controls in rows for better layout

Benefits:
- No keyboard capture during selection
- All options visible at a glance
- One-click selection (no menu navigation)
- Better for live performance
- Touch-friendly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks the arpeggiator UI to avoid dropdown focus capture and improve live usability.
> 
> - Replaces five arpeggiator selects with `btn-group` buttons (Pattern, Division, Timing, Accent, Ratchet) arranged in `arp-row`s in `index.html`
> - Adds `btn-group` styles and `arp-row` layout in `styles.css`
> - Extends control wiring in `main.ts` to support `btn-group` (click handling, active state, container `data-value`) and adds `updateButtonGroupValue`
> - Updates Tab arpeggiator rate boost to sync `arp-division` button group; existing sliders/checkboxes retained
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c373673a39c467c56e51d15cb91a9df1b11f0fd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->