### PR TITLE
Add internal clock source for arpeggiator

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,10 +66,24 @@
         </div>
 
         <div class="control-group">
-            <label for="midi-clock-input">Clock Input</label>
+            <label for="clock-source">Clock Source</label>
+            <select id="clock-source" tabindex="-1">
+                <option value="external">External MIDI</option>
+                <option value="internal">Internal Clock</option>
+            </select>
+        </div>
+
+        <div class="control-group" id="external-clock-controls">
+            <label for="midi-clock-input">MIDI Clock Input</label>
             <select id="midi-clock-input" tabindex="-1">
                 <option value="auto">Auto (Best)</option>
             </select>
+        </div>
+
+        <div class="control-group" id="internal-clock-controls" style="display: none;">
+            <label for="internal-bpm">BPM</label>
+            <input type="range" id="internal-bpm" min="20" max="240" value="120" step="1" tabindex="-1">
+            <span id="internal-bpm-value">120</span>
         </div>
 
         <div class="control-group">


### PR DESCRIPTION
- Extended ClockSync to support both external MIDI and internal clock sources
- Added clock source selector dropdown (External MIDI / Internal Clock)
- Added BPM slider (20-240 whole numbers) for internal clock
- Internal clock generates MIDI clock ticks programmatically using setInterval
- Arpeggiator works unchanged with both clock sources (event-driven architecture)
- Clock source and BPM controls show/hide based on selection
- Internal clock starts/stops automatically when arpeggiator is toggled
- UI updates to show internal clock BPM in clock status display

Implementation follows DRY and KISS principles:
- Reuses existing clock tick event system
- No changes needed to arpeggiator (uses same callbacks)
- Simple setInterval-based tick generation
- Unified UI handling for both clock sources