### PR TITLE
Add internal clock source for arpeggiator

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,8 +68,14 @@
         <div class="control-group">
             <label for="midi-clock-input">Clock Input</label>
             <select id="midi-clock-input" tabindex="-1">
-                <option value="auto">Auto (Best)</option>
+                <option value="internal">Internal</option>
+                <option value="auto">Auto (External)</option>
             </select>
+        </div>
+
+        <div class="control-group internal-bpm-control" id="internal-bpm-control">
+            <label for="internal-bpm">BPM: <span id="internal-bpm-value">120</span></label>
+            <input type="range" id="internal-bpm" min="20" max="240" value="120" step="1" tabindex="-1">
         </div>
 
         <div class="control-group">

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ class MIDIController {
   private initializing = true;
   // Prevents overlapping resume calls
   private resuming = false;
-  private preferredClockInputId: string = 'auto';
+  private preferredClockInputId: string = 'internal';
   // Momentary arpeggiator rate boost state (Tab key)
   private arpBoostActive: boolean = false;
   private arpBoostBaseDivisor: number | null = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -154,7 +154,7 @@ class MIDIController {
     this.uiController.onInternalBpmChange((bpm) => {
       this.clockSync.setInternalClockBPM(bpm);
       if (this.clockSync.isInternalClockRunning()) {
-        this.uiController.updateClockStatus('synced', bpm);
+        this.uiController.updateClockStatus('synced', bpm, true);
       }
     });
 
@@ -1210,7 +1210,7 @@ class MIDIController {
         const bpm = this.uiController.getInternalBpm();
         this.clockSync.startInternalClock(bpm);
         this.uiController.setInternalBpmVisible(true);
-        this.uiController.updateClockStatus('synced', bpm);
+        this.uiController.updateClockStatus('synced', bpm, true);
       } else if (this.preferredClockInputId === 'auto') {
         this.midiEngine.selectBestClockInput();
       } else {
@@ -1328,7 +1328,7 @@ class MIDIController {
       // Start internal clock with current BPM
       const bpm = this.uiController.getInternalBpm();
       this.clockSync.startInternalClock(bpm);
-      this.uiController.updateClockStatus('synced', bpm);
+      this.uiController.updateClockStatus('synced', bpm, true);
       return;
     }
 

--- a/src/midi-engine.ts
+++ b/src/midi-engine.ts
@@ -187,17 +187,24 @@ export class MIDIEngine {
 
   /**
    * Allows manual selection of MIDI clock input (e.g., from UI)
+   * @param input - The MIDI input to use for clock messages, or null to disable external clock
    */
-  setInput(input: WebMidi.MIDIInput): void {
+  setInput(input: WebMidi.MIDIInput | null): void {
     // Detach any existing listener to prevent duplicate clock ticks on re-select
     if (this.state.midiInput) {
       try {
         this.state.midiInput.removeEventListener('midimessage', this.handleMIDIMessage as any);
       } catch {}
     }
+
     this.state.midiInput = input;
-    this.state.midiInput.addEventListener('midimessage', this.handleMIDIMessage as any);
-    console.log(`Switched MIDI Clock Input to: ${input.name || 'Unknown'}`);
+
+    if (input) {
+      this.state.midiInput!.addEventListener('midimessage', this.handleMIDIMessage as any);
+      console.log(`Switched MIDI Clock Input to: ${input.name || 'Unknown'}`);
+    } else {
+      console.log('MIDI Clock Input disabled (using internal clock)');
+    }
   }
 
   /**

--- a/src/ui-controller.ts
+++ b/src/ui-controller.ts
@@ -958,7 +958,9 @@ export class UIController {
    * Gets the current internal BPM slider value
    */
   getInternalBpm(): number {
-    return this.internalBpmSlider ? parseInt(this.internalBpmSlider.value) : 120;
+    if (!this.internalBpmSlider) return 120;
+    const parsed = parseInt(this.internalBpmSlider.value, 10);
+    return isNaN(parsed) ? 120 : parsed;
   }
 
   /**
@@ -980,7 +982,8 @@ export class UIController {
   onInternalBpmChange(handler: (bpm: number) => void): void {
     if (!this.internalBpmSlider) return;
     this.internalBpmSlider.addEventListener('input', () => {
-      const bpm = parseInt(this.internalBpmSlider!.value);
+      const parsed = parseInt(this.internalBpmSlider!.value, 10);
+      const bpm = isNaN(parsed) ? 120 : parsed;
       // Update display
       const display = document.getElementById('internal-bpm-value');
       if (display) {

--- a/src/ui-controller.ts
+++ b/src/ui-controller.ts
@@ -644,18 +644,23 @@ export class UIController {
    * Updates the clock sync status display
    * @param status - The current clock sync status
    * @param bpm - Optional BPM to display
+   * @param isInternal - Whether using internal clock (shows "Internal Clock" instead of "Synced to DAW")
    */
-  updateClockStatus(status: 'synced' | 'free' | 'stopped', bpm?: number): void {
+  updateClockStatus(status: 'synced' | 'free' | 'stopped', bpm?: number, isInternal?: boolean): void {
     if (!this.clockStatusElement) return;
-    
+
     let icon: string;
     let text: string;
     let className: string;
-    
+
     switch (status) {
       case 'synced':
         icon = '🟢';
-        text = bpm ? `Synced to DAW (${Math.round(bpm)} BPM)` : 'Synced to DAW';
+        if (isInternal) {
+          text = bpm ? `Internal Clock (${Math.round(bpm)} BPM)` : 'Internal Clock';
+        } else {
+          text = bpm ? `Synced to DAW (${Math.round(bpm)} BPM)` : 'Synced to DAW';
+        }
         className = 'clock-status synced';
         break;
       case 'free':

--- a/src/ui-controller.ts
+++ b/src/ui-controller.ts
@@ -26,6 +26,8 @@ export class UIController {
   private clockStatusElement: HTMLElement;
   private midiClockInputSelect: HTMLSelectElement | null = null;
   private midiNoteInputSelect: HTMLSelectElement | null = null;
+  private internalBpmSlider: HTMLInputElement | null = null;
+  private internalBpmControl: HTMLElement | null = null;
   private beatIndicatorTimeout?: ReturnType<typeof setTimeout>; // Store timeout to prevent overlapping pulses
   private modIndicator: HTMLElement | null = null;
   private pitchIndicator: HTMLElement | null = null;
@@ -61,6 +63,8 @@ export class UIController {
     this.clockStatusElement = document.getElementById('clock-status')!;
     this.midiClockInputSelect = document.getElementById('midi-clock-input') as HTMLSelectElement | null;
     this.midiNoteInputSelect = document.getElementById('midi-note-input') as HTMLSelectElement | null;
+    this.internalBpmSlider = document.getElementById('internal-bpm') as HTMLInputElement | null;
+    this.internalBpmControl = document.getElementById('internal-bpm-control');
     this.modIndicator = document.getElementById('mod-indicator');
     this.pitchIndicator = document.getElementById('pitch-indicator');
     this.octaveDownIndicator = document.getElementById('octave-down-indicator');
@@ -865,15 +869,24 @@ export class UIController {
   /**
    * Populate the MIDI Clock Input dropdown
    */
-  populateClockInputs(inputs: { id: string; name: string }[], selected: string = 'auto'): void {
+  populateClockInputs(inputs: { id: string; name: string }[], selected: string = 'internal'): void {
     if (!this.midiClockInputSelect) return;
     const select = this.midiClockInputSelect;
     select.innerHTML = '';
+
+    // Add Internal clock option first
+    const internalOption = document.createElement('option');
+    internalOption.value = 'internal';
+    internalOption.textContent = 'Internal';
+    select.appendChild(internalOption);
+
+    // Add Auto (external) option
     const autoOption = document.createElement('option');
     autoOption.value = 'auto';
-    autoOption.textContent = 'Auto (Best)';
+    autoOption.textContent = 'Auto (External)';
     select.appendChild(autoOption);
 
+    // Add external MIDI inputs
     inputs.forEach(inp => {
       const opt = document.createElement('option');
       opt.value = inp.id;
@@ -882,8 +895,8 @@ export class UIController {
     });
 
     // Validate that selected value exists in options before setting
-    const validIds = ['auto', ...inputs.map(i => i.id)];
-    select.value = validIds.includes(selected) ? selected : 'auto';
+    const validIds = ['internal', 'auto', ...inputs.map(i => i.id)];
+    select.value = validIds.includes(selected) ? selected : 'internal';
   }
 
   /**
@@ -928,6 +941,52 @@ export class UIController {
     if (!this.midiNoteInputSelect) return;
     this.midiNoteInputSelect.addEventListener('change', () => {
       handler(this.midiNoteInputSelect!.value);
+    });
+  }
+
+  /**
+   * Shows or hides the internal BPM control
+   * @param visible - Whether to show the control
+   */
+  setInternalBpmVisible(visible: boolean): void {
+    if (this.internalBpmControl) {
+      this.internalBpmControl.style.display = visible ? 'block' : 'none';
+    }
+  }
+
+  /**
+   * Gets the current internal BPM slider value
+   */
+  getInternalBpm(): number {
+    return this.internalBpmSlider ? parseInt(this.internalBpmSlider.value) : 120;
+  }
+
+  /**
+   * Sets the internal BPM slider value
+   */
+  setInternalBpm(bpm: number): void {
+    if (this.internalBpmSlider) {
+      this.internalBpmSlider.value = String(bpm);
+      const display = document.getElementById('internal-bpm-value');
+      if (display) {
+        display.textContent = String(bpm);
+      }
+    }
+  }
+
+  /**
+   * Listen for internal BPM slider changes
+   */
+  onInternalBpmChange(handler: (bpm: number) => void): void {
+    if (!this.internalBpmSlider) return;
+    this.internalBpmSlider.addEventListener('input', () => {
+      const bpm = parseInt(this.internalBpmSlider!.value);
+      // Update display
+      const display = document.getElementById('internal-bpm-value');
+      if (display) {
+        display.textContent = String(bpm);
+      }
+      handler(bpm);
     });
   }
 

--- a/styles.css
+++ b/styles.css
@@ -355,6 +355,26 @@ body {
     box-shadow: 0 0 8px rgba(76, 175, 80, 0.35);
 }
 
+/* Internal BPM slider control */
+.internal-bpm-control {
+    padding: 10px 15px;
+}
+
+.internal-bpm-control label {
+    font-size: 13px;
+}
+
+.internal-bpm-control input[type="range"] {
+    width: 100%;
+    margin: 5px 0 0 0;
+    cursor: pointer;
+}
+
+#internal-bpm-value {
+    font-weight: 600;
+    color: var(--accent-color, #4CAF50);
+}
+
 .piano-container {
     background: var(--piano-bg);
     padding: 20px;


### PR DESCRIPTION
Adds an internal clock option that generates MIDI clock ticks when
external MIDI clock isn't available. Features:
- Internal clock mode as default (selectable via Clock Input dropdown)
- BPM slider (20-240) for controlling internal clock tempo
- Automatic start/stop when switching between internal and external clock
- Proper cleanup on suspend and restart on resume